### PR TITLE
fix: 修复会读取到非指定环境的appsettings的问题

### DIFF
--- a/src/Library/NetPro.Startup/NetProStartup.cs
+++ b/src/Library/NetPro.Startup/NetProStartup.cs
@@ -99,12 +99,12 @@ namespace System.NetPro.Startup._
 
                 _configuration = builder.Build();
 
-                var jsonFilePath = _configuration.GetValue<string>("ConfigPath",".");
+                var jsonFilePath = _configuration.GetValue<string>("ConfigPath", ".");
 
                 //Load all jSON-formatted files as configuration
                 foreach (var file in Directory.GetFiles(jsonFilePath, $"*.json"))
                 {
-                    if (file.Contains("runtimeconfig.template.json") || file.Contains($"appsettings.{env}.json") || file.Contains($"appsettings.json"))
+                    if (file.Contains("runtimeconfig.template.json") || file.Contains($"appsettings."))
                         continue;
 
                     builder.AddJsonFile(file, true, true);


### PR DESCRIPTION
当多个环境的`appsettings`配置文件同时存在于项目启动目录时，由于只会跳过`appsettings.json`和`appsettings.{env}.json`配置文件的加载，会导致其它环境的`appsettings`配置文件被读取，如：

```plaintext
appsettings.Development.json
appsettings.json
appsettings.LocalTest.json
appsettings.Production.json
NetPro.Sample.API.csproj
```

在`Development`环境，配置项会被`Production`环境的配置项覆盖