### PR TITLE
停用swagger-ui的语法高亮

### DIFF
--- a/src/Library/NetPro.Swagger/NetProSwaggerServiceExtensions.cs
+++ b/src/Library/NetPro.Swagger/NetProSwaggerServiceExtensions.cs
@@ -227,6 +227,7 @@ namespace NetPro.Swagger
                     var prefix = !string.IsNullOrEmpty(basePath) ? $"/{basePath}/" : "/";
                     c.SwaggerEndpoint($"{prefix}docs/v1/docs.json", $"{swaggerOption.Title}");//此处配置要和UseSwagger的RouteTemplate匹配
                     c.SwaggerEndpoint("https://petstore.swagger.io/v2/swagger.json", "petstore.swagger");//远程swagger示例
+                    c.ConfigObject.AdditionalItems["syntaxHighlight"] = false;
 
                     #region
                     typeof(NetProSwaggerMiddlewareExtensions).GetTypeInfo().Assembly.GetManifestResourceStream("NetPro.Swagger.SwaggerProfiler.html");


### PR DESCRIPTION
参考：https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/1980

当不停用`swagger-ui`的语法高亮时，如果响应内容较大，需要花费大量时间处理语法高亮，会导致较长时间才能看到响应内容，或者页面停止响应。建议关闭语法高亮，或者调整为可以配置，从而满足实际使用的需要